### PR TITLE
refactor: package structure + tests + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fraud-model"
+version = "0.1.0"
+description = "Fraud detection model package"
+authors = [{name = "Unknown"}]
+requires-python = ">=3.8"
+dependencies = [
+    "pandas",
+    "numpy",
+    "scikit-learn",
+    "imbalanced-learn",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/train_cli.py
+++ b/scripts/train_cli.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Command line interface to train the fraud model."""
+
+import argparse
+import pandas as pd
+
+from fraud_model.train import train
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train fraud model on a CSV dataset")
+    parser.add_argument("csv", type=str, help="Path to CSV file containing a 'Class' column")
+    args = parser.parse_args()
+    df = pd.read_csv(args.csv)
+    _, metrics = train(df)
+    for key, value in metrics.items():
+        print(f"{key}: {value:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fraud_model/__init__.py
+++ b/src/fraud_model/__init__.py
@@ -1,0 +1,3 @@
+"""Fraud model package."""
+
+__all__ = ["train", "utils"]

--- a/src/fraud_model/train.py
+++ b/src/fraud_model/train.py
@@ -1,0 +1,45 @@
+"""Training logic extracted from the notebook."""
+
+from __future__ import annotations
+
+import pandas as pd
+from sklearn.ensemble import ExtraTreesClassifier
+from sklearn.metrics import (
+    average_precision_score,
+    roc_auc_score,
+    f1_score,
+    precision_score,
+    recall_score,
+    matthews_corrcoef,
+)
+from sklearn.model_selection import train_test_split
+from imblearn.over_sampling import SMOTE
+
+from .utils import preprocess_features_safely
+
+
+def train(df: pd.DataFrame):
+    """Train a baseline model on *df* and return the fitted model and metrics."""
+    df_proc = preprocess_features_safely(df)
+    X_all, y_all = df_proc.drop("Class", axis=1), df_proc["Class"]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X_all, y_all, test_size=0.3, stratify=y_all, random_state=42
+    )
+    smote = SMOTE(random_state=42)
+    X_train_b, y_train_b = smote.fit_resample(X_train, y_train)
+    model = ExtraTreesClassifier(n_estimators=100, random_state=42, n_jobs=-1)
+    model.fit(X_train_b, y_train_b)
+    proba = model.predict_proba(X_test)[:, 1]
+    pred = (proba > 0.5).astype(int)
+    metrics = {
+        "PR_AUC": average_precision_score(y_test, proba),
+        "ROC_AUC": roc_auc_score(y_test, proba),
+        "F1": f1_score(y_test, pred),
+        "Precision": precision_score(y_test, pred, zero_division=0),
+        "Recall": recall_score(y_test, pred, zero_division=0),
+        "MCC": matthews_corrcoef(y_test, pred),
+    }
+    return model, metrics
+
+
+__all__ = ["train"]

--- a/src/fraud_model/utils.py
+++ b/src/fraud_model/utils.py
@@ -1,0 +1,20 @@
+"""Utility functions for fraud model training."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+def preprocess_features_safely(df_in: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of *df_in* with categorical and numeric data cleaned.
+
+    - Categorical columns are converted to integer codes.
+    - Numeric columns are coerced to numbers and NaNs replaced with the median.
+    """
+    df_p = df_in.copy()
+    for col in df_p.select_dtypes(include=["object", "category"]).columns:
+        df_p[col] = df_p[col].astype("category").cat.codes
+    for col in df_p.select_dtypes(include=[np.number]).columns:
+        df_p[col] = pd.to_numeric(df_p[col], errors="coerce")
+        df_p[col] = df_p[col].fillna(df_p[col].median())
+    return df_p

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from sklearn.datasets import make_classification
+
+from fraud_model.train import train
+
+
+def test_train_runs():
+    X, y = make_classification(
+        n_samples=200,
+        n_features=5,
+        n_informative=3,
+        n_redundant=0,
+        random_state=42,
+    )
+    df = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
+    df["Class"] = y
+    model, metrics = train(df)
+    assert hasattr(model, "predict")
+    assert set(metrics.keys()) == {"PR_AUC", "ROC_AUC", "F1", "Precision", "Recall", "MCC"}


### PR DESCRIPTION
## Summary
- convert training notebook logic into package `fraud_model`
- add simple CLI entrypoint for training
- provide pytest-based unit test and CI workflow

## Testing
- `pip install .[test]` (fails: Could not find a version that satisfies the requirement setuptools>=61)
- `pytest` (fails: ModuleNotFoundError: No module named 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_68bf53b997a08321ae50918fdf6e26bc