### PR TITLE
Add packaging and CI for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install package
+        run: |
+          pip install -e .
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+build/
+dist/
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# code-2
+# Fraud Detection Utilities
+
+This repository contains a demonstration notebook and simple utility functions for fraud detection analysis.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Running tests
+
+```bash
+pytest
+```

--- a/fraud_detection/__init__.py
+++ b/fraud_detection/__init__.py
@@ -1,0 +1,5 @@
+"""Simple utilities for fraud detection analysis."""
+
+def add(a: int, b: int) -> int:
+    """Add two integers and return the result."""
+    return a + b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fraud_detection"
+version = "0.1.0"
+description = "Simple utilities for fraud detection analysis"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{ name = "OpenAI Assistant" }]
+license = { text = "MIT" }
+keywords = ["fraud", "detection", "analysis"]
+dependencies = [
+    "pandas",
+    "numpy",
+    "scikit-learn"
+]
+
+[project.urls]
+"Homepage" = "https://example.com/fraud_detection"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fraud_detection import add
+
+def test_add():
+    assert add(1, 2) == 3


### PR DESCRIPTION
## Summary
- add basic fraud_detection package with simple utility function
- configure project metadata with pyproject
- set up pytest test and GitHub Actions workflow

## Testing
- `python -m pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `python -m pip install --no-deps --no-build-isolation -e .` *(fails: invalid command 'bdist_wheel')*
- `pytest tests/test_basic.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c0687f8dd883219293dd358b989ff5