### PR TITLE
feat: training entrypoint + CLI + README + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,39 @@
 # Fraud Detection Utilities
 
-This repository contains a demonstration notebook and simple utility functions for fraud detection analysis.
+This repository provides simple utilities and a tiny training entrypoint for
+experimentation with fraud detection models.
 
 ## Installation
 
 ```bash
-pip install -e .
+pip install -e .[tests]
 ```
 
 ## Running tests
 
 ```bash
-pytest
+pytest -q
+```
+
+## Usage
+
+Train a model by running the package as a module:
+
+```bash
+python -m fraud_detection --input data.csv --epochs 5 --lr 0.01 --outdir outputs
+```
+
+The same entrypoint is also available directly:
+
+```bash
+python -m fraud_detection.train --input data.csv --epochs 5 --lr 0.01 --outdir outputs
+```
+
+## Colab quick start
+
+```python
+!git clone https://github.com/your-username/fraud_detection.git
+%cd fraud_detection
+!pip install -e .[tests]
+!python -m fraud_detection --input data.csv --outdir outputs
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,14 @@ dependencies = [
     "scikit-learn"
 ]
 
+[project.optional-dependencies]
+tests = ["pytest>=8,<9"]
+
 [project.urls]
 "Homepage" = "https://example.com/fraud_detection"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/train_cli.py
+++ b/scripts/train_cli.py
@@ -1,0 +1,5 @@
+"""Command line helper for training."""
+from fraud_detection.train import main
+
+if __name__ == "__main__":
+    main()

--- a/src/fraud_detection/__init__.py
+++ b/src/fraud_detection/__init__.py
@@ -1,5 +1,9 @@
 """Simple utilities for fraud detection analysis."""
+from .train import train
+
 
 def add(a: int, b: int) -> int:
     """Add two integers and return the result."""
     return a + b
+
+__all__ = ["add", "train"]

--- a/src/fraud_detection/__main__.py
+++ b/src/fraud_detection/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running the package as a module."""
+from .train import main
+
+if __name__ == "__main__":
+    main()

--- a/src/fraud_detection/train.py
+++ b/src/fraud_detection/train.py
@@ -1,0 +1,42 @@
+"""Training utilities for fraud detection."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+def train(input_path: str, epochs: int, lr: float, outdir: str) -> str:
+    """Dummy training routine.
+
+    Args:
+        input_path: Path to training data.
+        epochs: Number of epochs to train for.
+        lr: Learning rate.
+        outdir: Directory to write outputs to.
+
+    Returns:
+        Path to a file representing the trained model.
+    """
+    out_dir = Path(outdir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model_path = out_dir / "model.txt"
+    with model_path.open("w", encoding="utf-8") as f:
+        f.write(f"trained on {input_path} for {epochs} epochs with lr {lr}\n")
+    return str(model_path)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Command line interface for training.
+
+    Parses command line arguments and invokes :func:`train`.
+    """
+    parser = argparse.ArgumentParser(description="Train a fraud detection model")
+    parser.add_argument("--input", required=True, help="Path to input data")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of epochs")
+    parser.add_argument("--lr", type=float, default=0.001, help="Learning rate")
+    parser.add_argument("--outdir", default=".", help="Directory to place outputs")
+    args = parser.parse_args(argv)
+    train(args.input, args.epochs, args.lr, args.outdir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add training entrypoint with CLI and package module
- restructure package into src layout and export train
- provide install extras and refreshed README

## Testing
- `python -m pip install -e .[tests]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c085cd43fc8321a2f360705a36316d